### PR TITLE
Extend URL Object to display remain

### DIFF
--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -1,5 +1,3 @@
-import { URLData } from "./URLData/URLData";
-
 export function openURLDB(): IDBOpenDBRequest {
   const req = indexedDB.open("AlphaDB", 1);
 

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -1,10 +1,10 @@
 import { createConnectedStore } from "undux";
-import { URLData } from "./URLData/URLData";
 import { withIndexDB } from "./withIndexDB";
+import { IURL } from "./URL/IURL";
 
 export interface StoreInterface {
   href: string;
-  urls: URLData[];
+  urls: IURL[];
 }
 
 export const Store = createConnectedStore<StoreInterface>(

--- a/src/URL/ExtendURL/ExtendURL.ts
+++ b/src/URL/ExtendURL/ExtendURL.ts
@@ -1,32 +1,32 @@
-export interface URLData {
-  createdAt: Date;
-  href: string;
-  id?: number;
-  invisibleCause: INVISIBLE_CAUSE;
-}
-
-export const CLICKED_URL = "CLICKED_URL";
-export const EXCEED_DAY = "EXCEED_DAY";
-export const NOT_EXPIRED = "NOT_EXPIRED";
-
-type INVISIBLE_CAUSE =
-  | typeof CLICKED_URL
-  | typeof EXCEED_DAY
-  | typeof NOT_EXPIRED;
+import { IURL } from "../IURL";
+import {
+  EXCEED_DAY,
+  NOT_EXPIRED,
+  INVISIBLE_CAUSE,
+  CLICKED_URL
+} from "../inner/type";
 
 const DELTA_TIME_BY_DELETE = 10 * 24 * 60 * 60 * 1000;
 
-export class ExtendedURL {
-  private urlData: URLData;
-  public static generate(url: URLData): ExtendedURL {
-    const extendURL = new ExtendedURL(url);
-    if (extendURL.getRemainTimeMs() < 0) {
+export class ExtendURL {
+  private urlData: IURL;
+  public static generate(url: IURL): ExtendURL {
+    const extendURL = new ExtendURL(url);
+    if (
+      extendURL.getRemainTimeMs() < 0 &&
+      extendURL.invisibleCause === NOT_EXPIRED
+    ) {
       extendURL.invisibleCause = EXCEED_DAY;
     }
     return extendURL;
   }
-  private constructor(url: URLData) {
+  private constructor(url: IURL) {
     this.urlData = url;
+  }
+  public clickedURL() {
+    if (this.urlData.invisibleCause === NOT_EXPIRED) {
+      this.urlData.invisibleCause = CLICKED_URL;
+    }
   }
   get id(): number {
     return this.urlData.id;
@@ -47,10 +47,18 @@ export class ExtendedURL {
     const hour = Math.floor(ms / HOUR_MS);
     return [day, hour];
   }
+  public isExpired(): boolean {
+    return this.getRemainTimeMs() < 0;
+  }
   set invisibleCause(cause: INVISIBLE_CAUSE) {
     this.urlData.invisibleCause = cause;
   }
-  public build(): URLData {
+  public build(): IURL {
     return Object.assign({}, this.urlData);
   }
+}
+
+export function updateURLVisible(url: IURL): IURL {
+  const u = ExtendURL.generate(url);
+  return u.build();
 }

--- a/src/URL/IURL.ts
+++ b/src/URL/IURL.ts
@@ -1,0 +1,12 @@
+import { INVISIBLE_CAUSE, NOT_EXPIRED } from "./inner/type";
+
+export interface IURL {
+  createdAt: Date;
+  href: string;
+  id?: number;
+  invisibleCause: INVISIBLE_CAUSE;
+}
+
+export function generateURL(href: string): IURL {
+  return { createdAt: new Date(), href, invisibleCause: NOT_EXPIRED };
+}

--- a/src/URL/inner/type.ts
+++ b/src/URL/inner/type.ts
@@ -1,0 +1,8 @@
+export const CLICKED_URL = "CLICKED_URL";
+export const EXCEED_DAY = "EXCEED_DAY";
+export const NOT_EXPIRED = "NOT_EXPIRED";
+
+export type INVISIBLE_CAUSE =
+  | typeof CLICKED_URL
+  | typeof EXCEED_DAY
+  | typeof NOT_EXPIRED;

--- a/src/URLData/URLData.ts
+++ b/src/URLData/URLData.ts
@@ -5,11 +5,6 @@ export interface URLData {
   invisibleCause: INVISIBLE_CAUSE;
 }
 
-/*export const CLICKED_URL = Symbol("CLICKED_URL");
-export const EXCEED_DAY = Symbol("EXCEED_DAY");
-export const NOT_EXPIRED = Symbol("NOT_EXPIRED");
-*/
-
 export const CLICKED_URL = "CLICKED_URL";
 export const EXCEED_DAY = "EXCEED_DAY";
 export const NOT_EXPIRED = "NOT_EXPIRED";
@@ -18,3 +13,44 @@ type INVISIBLE_CAUSE =
   | typeof CLICKED_URL
   | typeof EXCEED_DAY
   | typeof NOT_EXPIRED;
+
+const DELTA_TIME_BY_DELETE = 10 * 24 * 60 * 60 * 1000;
+
+export class ExtendedURL {
+  private urlData: URLData;
+  public static generate(url: URLData): ExtendedURL {
+    const extendURL = new ExtendedURL(url);
+    if (extendURL.getRemainTimeMs() < 0) {
+      extendURL.invisibleCause = EXCEED_DAY;
+    }
+    return extendURL;
+  }
+  private constructor(url: URLData) {
+    this.urlData = url;
+  }
+  get id(): number {
+    return this.urlData.id;
+  }
+  public getRemainTimeMs(): number {
+    return (
+      this.urlData.createdAt.getTime() +
+      DELTA_TIME_BY_DELETE -
+      new Date().getTime()
+    );
+  }
+  public getRemainTime(): number[] {
+    const HOUR_MS = 60 * 60 * 1000;
+    const DAY_MS = 24 * HOUR_MS;
+    let ms = this.getRemainTimeMs();
+    const day = Math.floor(ms / DAY_MS);
+    ms -= day * DAY_MS;
+    const hour = Math.floor(ms / HOUR_MS);
+    return [day, hour];
+  }
+  set invisibleCause(cause: INVISIBLE_CAUSE) {
+    this.urlData.invisibleCause = cause;
+  }
+  public build(): URLData {
+    return Object.assign({}, this.urlData);
+  }
+}

--- a/src/component/molecules/URLItem/URLItem.tsx
+++ b/src/component/molecules/URLItem/URLItem.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { URLData } from "../../../URLData/URLData";
+import { URLData, ExtendedURL } from "../../../URLData/URLData";
 
 interface Props {
   url: URLData;
 }
 
 export const URLItem: React.FC<Props> = ({ url }) => {
+  const remainTime = ExtendedURL.generate(url).getRemainTime();
   return (
     <li key={url.id}>
       <a
@@ -15,6 +16,7 @@ export const URLItem: React.FC<Props> = ({ url }) => {
       >
         {url.href}
       </a>
+      <span>{`あと${remainTime[0]}日${remainTime[1]}時間`}</span>
     </li>
   );
 };

--- a/src/component/molecules/URLItem/URLItem.tsx
+++ b/src/component/molecules/URLItem/URLItem.tsx
@@ -1,12 +1,13 @@
 import React from "react";
-import { URLData, ExtendedURL } from "../../../URLData/URLData";
+import { ExtendURL } from "../../../URL/ExtendURL/ExtendURL";
+import { IURL } from "../../../URL/IURL";
 
 interface Props {
-  url: URLData;
+  url: IURL;
 }
 
 export const URLItem: React.FC<Props> = ({ url }) => {
-  const remainTime = ExtendedURL.generate(url).getRemainTime();
+  const remainTime = ExtendURL.generate(url).getRemainTime();
   return (
     <li key={url.id}>
       <a

--- a/src/component/organisms/UrlArea.tsx
+++ b/src/component/organisms/UrlArea.tsx
@@ -3,7 +3,8 @@ import {
   URLData,
   CLICKED_URL,
   EXCEED_DAY,
-  NOT_EXPIRED
+  NOT_EXPIRED,
+  ExtendedURL
 } from "../../URLData/URLData";
 import { Store, StoreInterface } from "../../Store";
 import { dbManipulator } from "../../Storage";
@@ -23,15 +24,8 @@ class UrlAreaComponent extends React.Component<{ store }> {
       const getReq = objStore.getAll();
       getReq.onsuccess = event => {
         let urls: URLData[] = getReq.result;
-        const deltaTimeByDelete = 10 * 24 * 60 * 60 * 1000;
         urls = urls.map((url: URLData) => {
-          if (
-            url.createdAt.getTime() + deltaTimeByDelete <
-            new Date().getTime()
-          ) {
-            url.invisibleCause = EXCEED_DAY;
-          }
-          return url;
+          return ExtendedURL.generate(url).build();
         });
         store.set("urls")(urls);
       };

--- a/src/component/organisms/UrlArea.tsx
+++ b/src/component/organisms/UrlArea.tsx
@@ -1,15 +1,10 @@
 import React from "react";
-import {
-  URLData,
-  CLICKED_URL,
-  EXCEED_DAY,
-  NOT_EXPIRED,
-  ExtendedURL
-} from "../../URLData/URLData";
-import { Store, StoreInterface } from "../../Store";
+import { Store } from "../../Store";
 import { dbManipulator } from "../../Storage";
 import { URLRegister } from "../molecules/URLRegister/URLRegister";
 import { URLItem } from "../molecules/URLItem/URLItem";
+import { IURL, generateURL } from "../../URL/IURL";
+import { ExtendURL, updateURLVisible } from "../../URL/ExtendURL/ExtendURL";
 
 class UrlAreaComponent extends React.Component<{ store }> {
   constructor(props) {
@@ -23,9 +18,9 @@ class UrlAreaComponent extends React.Component<{ store }> {
     dbManipulator(objStore => {
       const getReq = objStore.getAll();
       getReq.onsuccess = event => {
-        let urls: URLData[] = getReq.result;
-        urls = urls.map((url: URLData) => {
-          return ExtendedURL.generate(url).build();
+        let urls: IURL[] = getReq.result;
+        urls = urls.map(url => {
+          return updateURLVisible(url);
         });
         store.set("urls")(urls);
       };
@@ -42,27 +37,26 @@ class UrlAreaComponent extends React.Component<{ store }> {
     event.preventDefault();
     const store = this.props.store;
     const href = store.get("href") as string;
-    const urls = store.get("urls") as URLData[];
+    const urls = store.get("urls") as IURL[];
 
     store.set("href")("");
-    store.set("urls")([
-      ...urls,
-      { createdAt: new Date(), href, invisibleCause: NOT_EXPIRED }
-    ]);
+    store.set("urls")([...urls, generateURL(href)]);
   }
 
   handleURLClicked(urlId: number) {
     const store = this.props.store;
-    const urls = store.get("urls") as URLData[];
+    const urls = store.get("urls") as IURL[];
     const changedIndex = urls.findIndex(url => url.id === urlId);
-    urls[changedIndex].invisibleCause = CLICKED_URL;
+    const extendURL = ExtendURL.generate(urls[changedIndex]);
+    extendURL.clickedURL();
+    urls[changedIndex] = extendURL.build();
     store.set("urls")(urls);
   }
 
   render() {
     const store = this.props.store;
     const href = store.get("href");
-    const urls = store.get("urls") as URLData[];
+    const urls = store.get("urls") as IURL[];
     return (
       <div className="url-area__container">
         <p>Sharing-MVP</p>
@@ -73,8 +67,14 @@ class UrlAreaComponent extends React.Component<{ store }> {
         ></URLRegister>
         <ul>
           {urls
-            .filter(url => url.invisibleCause === NOT_EXPIRED)
-            .map((url: URLData) => (
+            .map(url => {
+              return ExtendURL.generate(url);
+            })
+            .filter(url => !url.isExpired())
+            .map(extendURL => {
+              return extendURL.build();
+            })
+            .map((url: IURL) => (
               <URLItem key={url.id} url={url} />
             ))}
         </ul>

--- a/src/withIndexDB.ts
+++ b/src/withIndexDB.ts
@@ -1,11 +1,11 @@
 import { Effects } from "undux";
 import { StoreInterface } from "./Store";
-import { URLData } from "./URLData/URLData";
 import { dbManipulator } from "./Storage";
 import { zip } from "rxjs";
+import { IURL } from "./URL/IURL";
 
 export const withIndexDB: Effects<StoreInterface> = store => {
-  store.on("urls").subscribe((urls: URLData[]) => {
+  store.on("urls").subscribe((urls: IURL[]) => {
     dbManipulator(objStore => {
       const getAllKeysReq = objStore.getAllKeys();
       getAllKeysReq.addEventListener("success", event => {


### PR DESCRIPTION
# TODO
残り時間を表示する

# やったこと
この段階でURLという情報が持つべき機能を超えてしまったので、残り秒数からそれを日付と時刻に整形する機能などをExtendedURLクラスに持たせた。
一方でReactでは最小限のデータをpropsにとり表示させることが推奨されているのでリファクタは必要。